### PR TITLE
Trim for additional spaces.

### DIFF
--- a/HashingIdentificationExternalModule.php
+++ b/HashingIdentificationExternalModule.php
@@ -1304,7 +1304,7 @@ function findAddRecButton()
 {
 	var foundButton;
 		
-	$('.data').find('button').filter(function(){if($(this).text() === "Add new record"){ foundButton = $(this); }});
+	$('.data').find('button').filter(function(){if($(this).text().trim() === "Add new record"){ foundButton = $(this); }});
 	
 	return foundButton;
 }


### PR DESCRIPTION
On our enviroment the module doesn't start because of an extra space in front of the 'Add new record'. Trimming text fixes the issue.